### PR TITLE
Loosen up the requirements for django-hidp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Robin van Leeuwen", email = "rvanleeuwen@leukeleu.nl" },
 ]
 dependencies = [
-    "django-hidp>=1.4.0,<1.5.0",
+    "django-hidp>=1.4.0,<2",
 ]
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Make sure we can install django-hidp-django-admin with django-hidp 1.5.