### PR TITLE
[HIDP 246] styling improvements django admin

### DIFF
--- a/packages/hidp_django_admin/hidp_django_admin/static/css/hidp_django_admin.css
+++ b/packages/hidp_django_admin/hidp_django_admin/static/css/hidp_django_admin.css
@@ -140,3 +140,8 @@ div:has(> label + input[type="checkbox"]) label,
 p:has(> label + input[type="checkbox"]) label {
   margin: 0;
 }
+
+li a:link,
+p a:link {
+  text-decoration: underline;
+}

--- a/packages/hidp_django_admin/hidp_django_admin/static/css/hidp_django_admin.css
+++ b/packages/hidp_django_admin/hidp_django_admin/static/css/hidp_django_admin.css
@@ -141,7 +141,7 @@ p:has(> label + input[type="checkbox"]) label {
   margin: 0;
 }
 
-li a:link,
-p a:link {
+li a,
+p a {
   text-decoration: underline;
 }


### PR DESCRIPTION
Styles just links inside paragraphs and list elements, which afaik Django admin doesn't use. Did not style `Terug` as that one seemed obvious

![hackerman_images](https://github.com/user-attachments/assets/52e0644b-2695-45dd-b77c-cde9ed8230f5)

https://linear.app/leukeleu/issue/HIDP-246/styling-improvements-django-admin