### PR TITLE
[HIDP-254] Pre login: working theme toggle and white header textcolor

### DIFF
--- a/packages/hidp_django_admin/hidp_django_admin/templates/hidp/base_pre_login.html
+++ b/packages/hidp_django_admin/hidp_django_admin/templates/hidp/base_pre_login.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n static %}
+{% load csp_nonce i18n static %}
 
 {% block title %}
   {% if form.errors %}{% translate "Error:" %} {% endif %}{{ block.super }}
@@ -7,14 +7,15 @@
 
 {% block extrastyle %}
   {{ block.super }}
-  <link rel="stylesheet" href="{% static 'admin/css/login.css' %}">
   <link rel="stylesheet" href="{% static 'admin/css/base.css' %}">
   {{ form.media }}
   <link rel="stylesheet" href="{% static 'css/hidp_django_admin_pre_login.css' %}">
   <link rel="stylesheet" href="{% static 'css/hidp_django_admin.css' %}">
   {% block dark-mode-vars %}
-    <link rel="stylesheet" href="{% static 'admin/css/dark_mode.css' %}">
+  <link rel="stylesheet" href="{% static 'admin/css/dark_mode.css' %}">
+  <script nonce="{% csp_nonce %}" src="{% static "admin/js/theme.js" %}"></script>
   {% endblock %}
+  <link rel="stylesheet" href="{% static 'admin/css/login.css' %}">
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} login{% endblock %}


### PR DESCRIPTION
Before this PR:
<img width="421" alt="Screenshot 2025-07-08 at 15 57 05" src="https://github.com/user-attachments/assets/f6b6b8ee-3926-4980-933a-0adce5a3db70" />

After this PR:
<img width="442" alt="Screenshot 2025-07-08 at 15 55 39" src="https://github.com/user-attachments/assets/0e3a509d-c077-42a6-908a-072b01ac0ac0" />

And for reference, the non-hidp login looks like this:
<img width="432" alt="Screenshot 2025-07-08 at 15 55 43" src="https://github.com/user-attachments/assets/8efe5197-a5fc-4543-b0b5-475ac229a23b" />
