### PR TITLE
Update to django-hidp 1.6.0 and style the new logout-button

### DIFF
--- a/packages/hidp_django_admin/hidp_django_admin/static/css/hidp_django_admin.css
+++ b/packages/hidp_django_admin/hidp_django_admin/static/css/hidp_django_admin.css
@@ -89,7 +89,7 @@ form a.default:hover {
   text-decoration: underline;
 }
 
-form input[type="submit"].submit-link {
+form button[type="submit"].submit-link {
   background: none;
   color: var(--link-fg);
   text-decoration: none;
@@ -97,9 +97,11 @@ form input[type="submit"].submit-link {
   padding: 0;
   border: none;
   cursor: pointer;
+  font-size: 14px;
+  margin-bottom: 1rem;
 }
 
-form input[type="submit"].submit-link:hover {
+form button[type="submit"].submit-link:hover {
   color: var(--link-hover-color);
 }
 
@@ -133,4 +135,10 @@ p:has(> label + input[type="checkbox"]) {
 div:has(> label + input[type="checkbox"]) label,
 p:has(> label + input[type="checkbox"]) label {
   margin: 0;
+}
+
+.form-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }

--- a/packages/hidp_django_admin/hidp_django_admin/templates/hidp/includes/forms/logout_form.html
+++ b/packages/hidp_django_admin/hidp_django_admin/templates/hidp/includes/forms/logout_form.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% comment %}
+The logout_url is required for the form action. It is passed in from the view
+that renders this template. If the logout_url is not provided, the form will not
+be rendered.
+{% endcomment %}
+{% if logout_url %}
+<form action="{{ logout_url }}" method="post">
+    {% csrf_token %}
+    <button type="submit" class="submit-link">
+        {{ logout_label|default:_("Cancel and return to login") }}
+    </button>
+</form>
+{% endif %}

--- a/packages/hidp_django_admin/hidp_django_admin/templates/hidp/otp/setup_device.html
+++ b/packages/hidp_django_admin/hidp_django_admin/templates/hidp/otp/setup_device.html
@@ -1,0 +1,74 @@
+{% extends 'hidp/base_post_login.html' %}
+{% load i18n %}
+
+{% block title %}{% translate 'Two-factor Authentication' %}{% endblock %}
+
+{% block main %}
+<style>
+    .qr-code-container {
+        padding: 1rem;
+        background-color: white;
+        border-radius: 0.5rem;
+        display: inline-block;
+    }
+
+    .qr-code-image {
+        max-width: 100%;
+        height: auto;
+        width: 200px;
+        aspect-ratio: 1/1;
+    }
+
+    .otp-config-url {
+        white-space: pre-line;
+        word-break: break-all;
+    }
+</style>
+
+<h1>{% translate 'Set up two-factor authentication' %}</h1>
+
+<form method="post">
+    {% csrf_token %}
+
+    <h2>{% translate 'Scan the QR code' %}</h2>
+    <div class="qr-code-container">
+        <img class="qr-code-image" src="{{ qrcode|safe }}"
+            alt="{% translate 'QR code for setting up two-factor authentication. Scan with your authenticator app.' %}" />
+    </div>
+
+    <details>
+        <summary>
+            {% translate 'Having trouble scanning the QR code?' %}
+        </summary>
+        <p>
+            {% translate 'Enter the following URL in your authenticator app:' %}
+        <pre class="otp-config-url">{{ config_url}}</pre>
+        </p>
+    </details>
+
+    {{ form.non_field_errors }}
+
+    <p>
+        {{ form.otp_token.errors }}
+        {{ form.otp_token.label_tag }}
+        {{ form.otp_token }}
+    </p>
+
+    <h2>{% translate 'Recovery codes' %}</h2>
+    <pre>{{ recovery_codes }}</pre>
+
+    <p>
+        {{ form.confirm_stored_backup_tokens.errors }}
+        {{ form.confirm_stored_backup_tokens.label_tag }}
+        {{ form.confirm_stored_backup_tokens }}
+    </p>
+
+    <div class="form-row">
+        {% include 'hidp/includes/forms/submit_row.html' with submit_label=_('Submit') %}
+        <a href="{{ back_url }}">{% translate 'Back' %}</a>
+    </div>
+</form>
+
+{% include 'hidp/includes/forms/logout_form.html' %}
+
+{% endblock %}

--- a/packages/hidp_django_admin/pyproject.toml
+++ b/packages/hidp_django_admin/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
     { name = "Robin van Leeuwen", email = "rvanleeuwen@leukeleu.nl" },
 ]
 dependencies = [
-    "django-hidp>=1.4.0,<2",
+    "django-hidp>=1.6.0,<2",
 ]
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/project/requirements.txt
+++ b/project/requirements.txt
@@ -2,6 +2,6 @@ Django~=4.2.0
 django-email-bandit~=2.0.0
 leukeleu-django-checks~=1.2
 leukeleu-django-gdpr~=1.4
-django-hidp[recommended]~=1.5.0
+django-hidp[recommended]~=1.6.0
 psycopg2-binary~=2.9.6
 -e ../packages/hidp_django_admin


### PR DESCRIPTION
After this PR:

- django-hidp is updated to 1.6.0
- The new logout-button receives styling

Some screenshots:

<img width="456" height="353" alt="Screenshot 2025-07-25 at 13 02 51" src="https://github.com/user-attachments/assets/08071e62-de83-4102-aeef-56a8239c1a85" />
<img width="431" height="394" alt="Screenshot 2025-07-25 at 13 02 46" src="https://github.com/user-attachments/assets/f149fd57-fa5c-4b6f-85ae-4c4c04547755" />
<img width="523" height="242" alt="Screenshot 2025-07-25 at 13 02 14" src="https://github.com/user-attachments/assets/9cc5570c-37f6-4c85-ada9-1c1e7e20df4f" />
