### PR TITLE
[LKL-2163] Pin release-drafter/release-drafter to commit hash of v6.0.0

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Draft release
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348  # 6.0.0
         with:
           config-name: release-drafter/config.yml
           disable-autolabeler: true


### PR DESCRIPTION
release-drafter/release-drafter is currently on [v6.1.0](https://github.com/release-drafter/release-drafter/releases/tag/v6.1.0)