### PR TITLE
Added missing extrastyle block to base_post_login.html

### DIFF
--- a/packages/hidp_django_admin/hidp_django_admin/templates/hidp/base_post_login.html
+++ b/packages/hidp_django_admin/hidp_django_admin/templates/hidp/base_post_login.html
@@ -12,7 +12,7 @@
     <link rel="stylesheet" href="{% static 'admin/css/dark_mode.css' %}">
     <script src="{% static 'admin/js/theme.js' %}" nonce="{% csp_nonce %}"></script>
   {% endblock %}
-  {% block extrastyle %}{% endblock %}
+  {% block extra_head %}{% endblock %}
 </head>
 
 <body>


### PR DESCRIPTION
It would be nice if we could add the missing `{% block extrastyle %}` that matches the base_per_login.html and Django's `base_site.html`.

With this change it would be possible to add an extra stylesheet where we could override the Django default CSS vars to match our own design.